### PR TITLE
Avoid read timeout when polling after a sequence

### DIFF
--- a/pyvcam_wrapper/src/pyvcam/pvcmodule.cpp
+++ b/pyvcam_wrapper/src/pyvcam/pvcmodule.cpp
@@ -776,14 +776,16 @@ pvc_get_frame(PyObject *self, PyObject *args)
 
         Py_BEGIN_ALLOW_THREADS
         while (checkStatusResult == PV_OK) {
-
+            if (camInstance.newData_ || camInstance.abortData_) {
+                break;
+            }
             // We want to wait for a new frame, but every so often check if readout failed
             std::unique_lock<std::mutex> lock(g_frameMutex);
             static const int READOUT_FAILED_TIMEOUT = 200;
             g_conditionalVariable.wait_for(lock, std::chrono::milliseconds(READOUT_FAILED_TIMEOUT));
 
             checkStatusResult = pl_exp_check_status(hCam, &status, &byte_cnt);
-            if (camInstance.newData_ || camInstance.abortData_ || status == READOUT_FAILED || status == READOUT_COMPLETE) {
+            if (status == READOUT_FAILED || status == READOUT_COMPLETE) {
                 break;
             }
         }


### PR DESCRIPTION
After having taken a sequence of images, we need to call pvc_get_frame to pull the data out of the buffer into python memory. As written, each call to this function was waiting an extra 200ms unnecessarily. This is because, when we call pvc_get_frame in this situation, unlike when pvc_get_frame is used in live mode, there will never be a new frame. Rather, we are calling this function to get frames we've already captured.

To avoid the 200ms timeout, check whether there is existing data at the start of the while loop.